### PR TITLE
Added unit tests and fixed function check if node is end of word

### DIFF
--- a/TrieTree/TrieTree.cs
+++ b/TrieTree/TrieTree.cs
@@ -99,7 +99,6 @@ namespace TrieTree
             return current.EndOfWord;
         }
 
-
         /// <summary>
         /// Searches longest common prefix in Trie Tree
         /// </summary>
@@ -120,12 +119,12 @@ namespace TrieTree
 
                 TrieNode child = current.Children.First(c => c is not null);
 
+                prefix.Append(child.Content);
+
                 if (child.EndOfWord)
                 {
                     return prefix.ToString();
                 }
-
-                prefix.Append(child.Content);
 
                 current = child;
             }

--- a/TrieTreeTests/TrieTreeUnitTests.cs
+++ b/TrieTreeTests/TrieTreeUnitTests.cs
@@ -142,4 +142,55 @@ public class TrieTests
 
         Assert.True(_sut.Search("Earth"));
     }
+
+    [Fact]
+    public void LongestPrefix_ShouldReturnEmptyString_WhenRootContainsMoreThanOneChildren()
+    {
+        _sut.Insert("Fire")
+            .Insert("Firefighter")
+            .Insert("Fireblaze")
+            .Insert("Earthquake");
+
+        string longestPrefix = _sut.LongestPrefix();
+
+        Assert.Equal("", longestPrefix);
+    }
+
+    [Fact]
+    public void LongestPrefix_ShouldReturnEmptyString_WhenTrieTreeIsEmpty()
+    {
+        string longestPrefix = _sut.LongestPrefix();
+
+        Assert.Equal("", longestPrefix);
+    }
+
+    [Fact]
+    public void LongestPrefix_ShouldReturnCommonPrefix_WhenTreeContainsWordWithTheSameBeginning()
+    {
+        _sut.Insert("Wood")
+            .Insert("Woodcutter")
+            .Insert("Woodchopper");
+
+        string longestPrefix = _sut.LongestPrefix();
+
+        Assert.Equal("wood", longestPrefix);
+
+        _sut.Insert("Would");
+
+        longestPrefix = _sut.LongestPrefix();
+
+        Assert.Equal("wo", longestPrefix);
+
+        _sut.Insert("Write");
+
+        longestPrefix = _sut.LongestPrefix();
+
+        Assert.Equal("w", longestPrefix);
+
+        _sut.Delete("Write");
+
+        longestPrefix = _sut.LongestPrefix();
+
+        Assert.Equal("wo", longestPrefix);
+    }
 }


### PR DESCRIPTION
Added unit tests to check if longest common prefix function works fine. If check was put after appending content of node to stringbuilder